### PR TITLE
Fix compiler bug in deviceTransformReduce, if input and return type of the transform functor are different

### DIFF
--- a/include/vikunja/reduce/reduce.hpp
+++ b/include/vikunja/reduce/reduce.hpp
@@ -176,8 +176,8 @@ namespace vikunja
             detail::BlockThreadReduceKernel<blockSize, MemAccessPolicy, TRed, TTransformOperator, TReduceOperator>
                 multiBlockKernel;
 
-            using TIdentityTransformOperator = vikunja::operators::
-                UnaryOp<TAcc, detail::Identity<TRed>, typename std::iterator_traits<TInputIterator>::value_type>;
+            using TIdentityTransformOperator
+                = vikunja::operators::UnaryOp<TAcc, detail::Identity<TRed>, typename TTransformOperator::TRed>;
             detail::
                 BlockThreadReduceKernel<blockSize, MemAccessPolicy, TRed, TIdentityTransformOperator, TReduceOperator>
                     singleBlockKernel;

--- a/test/include/vikunja/test/utility.hpp
+++ b/test/include/vikunja/test/utility.hpp
@@ -20,8 +20,8 @@ namespace vikunja
 {
     namespace test
     {
-        template<typename TDim, typename TData>
-        inline std::string print_acc_info(TData const size)
+        template<typename TDim>
+        inline std::string print_acc_info(std::size_t const size)
         {
             std::stringstream strs;
 

--- a/test/integ/reduce/include/reduce_setup.hpp
+++ b/test/integ/reduce/include/reduce_setup.hpp
@@ -26,6 +26,7 @@ namespace vikunja
                 template<typename, typename>
                 class TAcc,
                 typename TData,
+                typename TDataResult,
                 typename TIdx = std::uint64_t>
             class TestSetupBase
                 : public vikunja::test::TestAlpakaSetup<TDim, TIdx, alpaka::AccCpuSerial, TAcc, alpaka::Blocking>
@@ -45,7 +46,7 @@ namespace vikunja
                 BufHost m_host_mem;
                 BufDev m_device_mem;
 
-                TData m_result = 0;
+                TDataResult m_result;
 
             private:
                 Vec calculate_extends(std::uint64_t const size)
@@ -69,7 +70,7 @@ namespace vikunja
                     return alpaka::getPtrNative(m_host_mem);
                 }
 
-                TData get_result() const
+                TDataResult get_result() const
                 {
                     return m_result;
                 }

--- a/test/integ/transform/include/transform_setup.hpp
+++ b/test/integ/transform/include/transform_setup.hpp
@@ -26,6 +26,7 @@ namespace vikunja
                 template<typename, typename>
                 class TAcc,
                 typename TData,
+                typename TDataResult,
                 typename TIdx = std::uint64_t>
             class TestSetupBase
                 : public vikunja::test::TestAlpakaSetup<TDim, TIdx, alpaka::AccCpuSerial, TAcc, alpaka::Blocking>
@@ -38,6 +39,8 @@ namespace vikunja
                 using Vec = alpaka::Vec<TDim, TIdx>;
                 using BufHost = alpaka::Buf<Host, TData, TDim, TIdx>;
                 using BufDev = alpaka::Buf<Acc, TData, TDim, TIdx>;
+                using BufHostResult = alpaka::Buf<Host, TDataResult, TDim, TIdx>;
+                using BufDevResult = alpaka::Buf<Acc, TDataResult, TDim, TIdx>;
 
                 std::uint64_t const m_size;
                 Vec m_extent;
@@ -45,8 +48,8 @@ namespace vikunja
                 BufHost m_host_input1_mem;
                 BufDev m_device_input1_mem;
 
-                BufHost m_host_output_mem;
-                BufDev m_device_output_mem;
+                BufHostResult m_host_output_mem;
+                BufDevResult m_device_output_mem;
 
             private:
                 Vec calculate_extends(std::uint64_t const size)
@@ -62,8 +65,8 @@ namespace vikunja
                     , m_extent(calculate_extends(memSize))
                     , m_host_input1_mem(alpaka::allocBuf<TData, TIdx>(Base::devHost, m_extent))
                     , m_device_input1_mem(alpaka::allocBuf<TData, TIdx>(Base::devAcc, m_extent))
-                    , m_host_output_mem(alpaka::allocBuf<TData, TIdx>(Base::devHost, m_extent))
-                    , m_device_output_mem(alpaka::allocBuf<TData, TIdx>(Base::devAcc, m_extent))
+                    , m_host_output_mem(alpaka::allocBuf<TDataResult, TIdx>(Base::devHost, m_extent))
+                    , m_device_output_mem(alpaka::allocBuf<TDataResult, TIdx>(Base::devAcc, m_extent))
                 {
                 }
 
@@ -72,7 +75,7 @@ namespace vikunja
                     return alpaka::getPtrNative(m_host_input1_mem);
                 }
 
-                TData* get_host_output_mem_ptr()
+                TDataResult* get_host_output_mem_ptr()
                 {
                     return alpaka::getPtrNative(m_host_output_mem);
                 }

--- a/test/integ/transform/src/Transform.cpp
+++ b/test/integ/transform/src/Transform.cpp
@@ -34,13 +34,14 @@ namespace vikunja
                 template<typename, typename>
                 class TAcc,
                 typename TData,
+                typename TDataResult = TData,
                 typename TIdx = std::uint64_t>
-            class TestSetupTransform : public TestSetupBase<TDim, TAcc, TData, TIdx>
+            class TestSetupTransform : public TestSetupBase<TDim, TAcc, TData, TDataResult, TIdx>
             {
             public:
-                using TestSetupBase<TDim, TAcc, TData, TIdx>::TestSetupBase;
+                using TestSetupBase<TDim, TAcc, TData, TDataResult, TIdx>::TestSetupBase;
 
-                using Base = typename vikunja::test::transform::TestSetupBase<TDim, TAcc, TData, TIdx>;
+                using Base = typename vikunja::test::transform::TestSetupBase<TDim, TAcc, TData, TDataResult, TIdx>;
 
                 template<typename TReduceFunctor>
                 void run(TReduceFunctor reduceFunctor)
@@ -71,28 +72,30 @@ namespace vikunja
                 typename TDim,
                 template<typename, typename>
                 class TAcc,
-                typename TData,
+                typename TData1,
+                typename TData2 = TData1,
+                typename TDataResult = TData1,
                 typename TIdx = std::uint64_t>
-            class TestSetupTransformDoubleInput : public TestSetupBase<TDim, TAcc, TData, TIdx>
+            class TestSetupTransformDoubleInput : public TestSetupBase<TDim, TAcc, TData1, TDataResult, TIdx>
             {
             private:
-                using Base = typename vikunja::test::transform::TestSetupBase<TDim, TAcc, TData, TIdx>;
-                using BufHost = typename Base::BufHost;
-                using BufDev = typename Base::BufDev;
+                using Base = typename vikunja::test::transform::TestSetupBase<TDim, TAcc, TData1, TDataResult, TIdx>;
+                using BufHost = alpaka::Buf<typename Base::Base::Host, TData2, TDim, TIdx>;
+                using BufDev = alpaka::Buf<typename Base::Base::Acc, TData2, TDim, TIdx>;
 
                 BufHost m_host_input2_mem;
                 BufDev m_device_input2_mem;
 
             public:
                 TestSetupTransformDoubleInput(uint64_t const memSize)
-                    : TestSetupBase<TDim, TAcc, TData, TIdx>(memSize)
-                    , m_host_input2_mem(alpaka::allocBuf<TData, TIdx>(Base::Base::devHost, Base::m_extent))
-                    , m_device_input2_mem(alpaka::allocBuf<TData, TIdx>(Base::Base::devAcc, Base::m_extent))
+                    : TestSetupBase<TDim, TAcc, TData1, TDataResult, TIdx>(memSize)
+                    , m_host_input2_mem(alpaka::allocBuf<TData2, TIdx>(Base::Base::devHost, Base::m_extent))
+                    , m_device_input2_mem(alpaka::allocBuf<TData2, TIdx>(Base::Base::devAcc, Base::m_extent))
                 {
                 }
 
 
-                TData* get_host_input2_mem_ptr()
+                TData2* get_host_input2_mem_ptr()
                 {
                     return alpaka::getPtrNative(m_host_input2_mem);
                 }
@@ -156,6 +159,14 @@ struct MathOperator
     }
 };
 
+template<typename TReturn, typename TData1, typename TData2>
+struct Sub
+{
+    ALPAKA_FN_HOST_ACC TReturn operator()(TData1 const i, TData2 const j) const
+    {
+        return static_cast<TReturn>(i) - static_cast<TReturn>(j);
+    }
+};
 
 TEMPLATE_TEST_CASE(
     "Test transform with lambda but without acc object",
@@ -169,7 +180,7 @@ TEMPLATE_TEST_CASE(
 
     auto size = GENERATE(1, 10, 777, 1 << 10);
 
-    INFO((vikunja::test::print_acc_info<Dim, Data>(size)));
+    INFO((vikunja::test::print_acc_info<Dim>(size)));
 
     vikunja::test::transform::TestSetupTransform<Dim, alpaka::ExampleDefaultAcc, Data> setup(size);
 
@@ -203,7 +214,7 @@ TEMPLATE_TEST_CASE(
 
     auto size = GENERATE(1, 10, 777, 1 << 10);
 
-    INFO((vikunja::test::print_acc_info<Dim, Data>(size)));
+    INFO((vikunja::test::print_acc_info<Dim>(size)));
 
     vikunja::test::transform::TestSetupTransform<Dim, alpaka::ExampleDefaultAcc, Data> setup(size);
 
@@ -237,7 +248,7 @@ TEMPLATE_TEST_CASE(
 
     auto size = GENERATE(1, 10, 777, 1 << 10);
 
-    INFO((vikunja::test::print_acc_info<Dim, Data>(size)));
+    INFO((vikunja::test::print_acc_info<Dim>(size)));
 
     vikunja::test::transform::TestSetupTransform<Dim, alpaka::ExampleDefaultAcc, Data> setup(size);
 
@@ -283,7 +294,7 @@ TEMPLATE_TEST_CASE(
 
     auto size = GENERATE(1, 10, 777, 1 << 10);
 
-    INFO((vikunja::test::print_acc_info<Dim, Data>(size)));
+    INFO((vikunja::test::print_acc_info<Dim>(size)));
 
     vikunja::test::transform::TestSetupTransform<Dim, alpaka::ExampleDefaultAcc, Data> setup(size);
 
@@ -317,6 +328,55 @@ TEMPLATE_TEST_CASE(
 }
 
 TEMPLATE_TEST_CASE(
+    "Test transform with lamba, acc object and different types for input and output",
+    "[transform][lambda][Acc]",
+    (alpaka::DimInt<1u>),
+    (alpaka::DimInt<2u>),
+    (alpaka::DimInt<3u>) )
+{
+    using Dim = TestType;
+    using Data = int;
+    using ReturnType = float;
+
+    auto size = GENERATE(1, 10, 777, 1 << 10);
+
+    INFO((vikunja::test::print_acc_info<Dim>(size)));
+
+    vikunja::test::transform::TestSetupTransform<Dim, alpaka::ExampleDefaultAcc, Data, ReturnType> setup(size);
+
+    // setup initial values
+    Data* const host_mem_ptr = setup.get_host_input1_mem_ptr();
+    std::uniform_int_distribution<Data> distribution(
+        std::numeric_limits<Data>::min(),
+        std::numeric_limits<Data>::max() - 1);
+    std::default_random_engine generator;
+    std::generate(
+        host_mem_ptr,
+        host_mem_ptr + size,
+        [&distribution, &generator]() { return distribution(generator); });
+
+    auto transform
+        = [] ALPAKA_FN_HOST_ACC(alpaka::ExampleDefaultAcc<Dim, std::uint64_t> const& acc, Data const i) -> ReturnType
+    { return alpaka::math::max(acc, static_cast<ReturnType>(i), static_cast<ReturnType>(1 << 10)) + 0.5f; };
+
+    setup.run(transform);
+
+    std::vector<ReturnType> expected_result;
+    expected_result.resize(size);
+    std::transform(
+        host_mem_ptr,
+        host_mem_ptr + size,
+        expected_result.begin(),
+        [](Data const i) -> ReturnType
+        { return std::max(static_cast<ReturnType>(i), static_cast<ReturnType>(1 << 10)) + 0.5f; });
+
+    ReturnType const* const result_ptr = setup.get_host_output_mem_ptr();
+    std::vector<ReturnType> result(result_ptr, result_ptr + size);
+
+    REQUIRE(result == expected_result);
+}
+
+TEMPLATE_TEST_CASE(
     "Test transform double input with operator but without acc object",
     "[transform][operator][Acc]",
     (alpaka::DimInt<1u>),
@@ -328,7 +388,7 @@ TEMPLATE_TEST_CASE(
 
     auto size = GENERATE(1, 10, 777, 1 << 10);
 
-    INFO((vikunja::test::print_acc_info<Dim, Data>(size)));
+    INFO((vikunja::test::print_acc_info<Dim>(size)));
 
     vikunja::test::transform::TestSetupTransformDoubleInput<Dim, alpaka::ExampleDefaultAcc, Data> setup(size);
 
@@ -375,7 +435,7 @@ TEMPLATE_TEST_CASE(
 
     auto size = GENERATE(1, 10, 777, 1 << 10);
 
-    INFO((vikunja::test::print_acc_info<Dim, Data>(size)));
+    INFO((vikunja::test::print_acc_info<Dim>(size)));
 
     vikunja::test::transform::TestSetupTransformDoubleInput<Dim, alpaka::ExampleDefaultAcc, Data> setup(size);
 
@@ -412,6 +472,59 @@ TEMPLATE_TEST_CASE(
 
     Data const* const result_ptr = setup.get_host_output_mem_ptr();
     std::vector<Data> result(result_ptr, result_ptr + size);
+
+    REQUIRE(result == expected_result);
+}
+
+TEMPLATE_TEST_CASE(
+    "Test transform double input with operator, without acc object and different types for input1, input2 and return "
+    "value",
+    "[transform][operator][Acc]",
+    (alpaka::DimInt<1u>),
+    (alpaka::DimInt<2u>),
+    (alpaka::DimInt<3u>) )
+{
+    using Dim = TestType;
+    using Data1 = std::uint64_t;
+    using Data2 = float;
+    using ReturnType = int;
+    int const min_value = 0;
+    int const max_value = 1000;
+
+    auto size = GENERATE(1, 10, 777, 1 << 10);
+
+    INFO((vikunja::test::print_acc_info<Dim>(size)));
+
+    vikunja::test::transform::TestSetupTransformDoubleInput<Dim, alpaka::ExampleDefaultAcc, Data1, Data2, ReturnType>
+        setup(size);
+
+    // setup initial values
+    Data1* const host_mem_ptr1 = setup.get_host_input1_mem_ptr();
+    std::uniform_int_distribution<Data1> distribution1(static_cast<Data1>(min_value), static_cast<Data1>(max_value));
+    std::default_random_engine generator1;
+    std::generate(
+        host_mem_ptr1,
+        host_mem_ptr1 + size,
+        [&distribution1, &generator1]() { return distribution1(generator1); });
+
+    Data2* const host_mem_ptr2 = setup.get_host_input2_mem_ptr();
+    std::uniform_real_distribution<Data2> distribution2(static_cast<Data2>(min_value), static_cast<Data2>(max_value));
+    std::default_random_engine generator2;
+    std::generate(
+        host_mem_ptr2,
+        host_mem_ptr2 + size,
+        [&distribution2, &generator2]() { return distribution2(generator2); });
+
+    Sub<ReturnType, Data1, Data2> transform;
+
+    setup.run(transform);
+
+    std::vector<ReturnType> expected_result;
+    expected_result.resize(size);
+    std::transform(host_mem_ptr1, host_mem_ptr1 + size, host_mem_ptr2, expected_result.begin(), transform);
+
+    ReturnType const* const result_ptr = setup.get_host_output_mem_ptr();
+    std::vector<ReturnType> result(result_ptr, result_ptr + size);
 
     REQUIRE(result == expected_result);
 }

--- a/test/unit/operators/src/Operators.cpp
+++ b/test/unit/operators/src/Operators.cpp
@@ -11,6 +11,8 @@
 
 #include <alpaka/alpaka.hpp>
 
+#include <utility>
+
 #include <catch2/catch.hpp>
 
 struct DummyAcc
@@ -86,6 +88,15 @@ struct UStruct2
     }
 };
 
+template<typename TAcc, typename TData>
+struct UMakePair
+{
+    std::pair<TData, TData> ALPAKA_FN_HOST_ACC operator()(TAcc const& acc, TData const& a) const
+    {
+        return std::make_pair(a, a);
+    }
+};
+
 TEST_CASE("UnaryOp", "[operators]")
 {
     DummyAcc dummyAcc;
@@ -113,8 +124,10 @@ TEST_CASE("UnaryOp", "[operators]")
 
     UStruct1 uStruct1;
     UStruct2<DummyAcc, double, int> uStruct2;
+    UMakePair<DummyAcc, double> makePair;
     REQUIRE(unaryRunner<DummyAcc>(dummyAcc, uStruct1, 1) == 2);
     REQUIRE(unaryRunner<DummyAcc>(dummyAcc, uStruct2, 6.8) == 6);
+    REQUIRE(unaryRunner<DummyAcc>(dummyAcc, makePair, 1.2) == std::make_pair(1.2, 1.2));
 }
 
 
@@ -184,6 +197,14 @@ struct BStruct2
     }
 };
 
+template<typename TAcc, typename TData1, typename TData2>
+struct BMakePair
+{
+    std::pair<TData1, TData2> ALPAKA_FN_HOST_ACC operator()(TAcc const& acc, TData1 const& a, TData2 const& b) const
+    {
+        return std::make_pair(a, b);
+    }
+};
 
 TEST_CASE("BinaryOp", "[operators]")
 {
@@ -209,6 +230,8 @@ TEST_CASE("BinaryOp", "[operators]")
 
     BStruct1 bStruct1;
     BStruct2<DummyAcc, int, float, double> bStruct2;
+    BMakePair<DummyAcc, int, float> makePair;
     REQUIRE(binaryRunner<DummyAcc>(dummyAcc, bStruct1, 1.3f, 4.7) == 6);
     REQUIRE(binaryRunner<DummyAcc>(dummyAcc, bStruct2, 3, 1.2) == 1.0);
+    REQUIRE(binaryRunner<DummyAcc>(dummyAcc, makePair, 1, 3.4f) == std::make_pair(1, 3.4f));
 }


### PR DESCRIPTION
Add test cases to test different transformation functions where the type of input and the return value are different.