### PR TITLE
several fixes for the CI

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -41,9 +41,10 @@ pull-request-validation:
 
 generate:
   stage: generator
-  image: alpine:latest
+  # fixed alpine version, because alpine 3.18 does not provide Python 3.10
+  image: alpine:3.17
   script:
-    - apk update && apk add python3 py3-pip
+    - apk update && apk add python3~=3.10 py3-pip
     - pip3 install -r ci/job_generator/requirements.txt
     - python3 ci/job_generator/job_generator.py ${CONTAINER_VERSION}
     - cat jobs.yml

--- a/ci/job_generator/generate_job_yaml.py
+++ b/ci/job_generator/generate_job_yaml.py
@@ -192,7 +192,7 @@ def job_variables(job: Dict[str, Tuple[str, str]]) -> Dict[str, str]:
         and job[ALPAKA_ACC_GPU_HIP_ENABLE][VERSION] != OFF
     ):
         # architecture of the Vega 64
-        cmake_extra_arg.append("-DGPU_TARGETS=gfx900")
+        cmake_extra_arg.append("-DGPU_TARGETS=${CI_GPU_ARCH}")
 
     if (
         ALPAKA_ACC_GPU_CUDA_ENABLE in job

--- a/ci/job_generator/requirements.txt
+++ b/ci/job_generator/requirements.txt
@@ -1,5 +1,5 @@
 alpaka-job-coverage >= 1.2.1
 allpairspy == 2.5.0
-typeguard
+typeguard < 3.0.0
 pyaml
 types-PyYAML

--- a/ci/job_generator/vikunja_filter.py
+++ b/ci/job_generator/vikunja_filter.py
@@ -13,19 +13,23 @@ from packaging import version as pk_version
 
 
 def vikunja_post_filter(row: List) -> bool:
-    # the minimum boost version for alpaka 0.9.0 is 1.74.0
-    if (
-        is_in_row(row, ALPAKA)
-        and is_in_row(row, BOOST)
-        and (
-            pk_version.parse(row[param_map[ALPAKA]][VERSION])
-            > pk_version.parse("0.8.0")
-            or row[param_map[ALPAKA]][VERSION] == "develop"
-        )
-        and pk_version.parse(row[param_map[BOOST]][VERSION])
-        < pk_version.parse("1.74.0")
-    ):
-        return False
+    if is_in_row(row, ALPAKA):
+        # the minimum boost version for alpaka 0.9.0 is 1.74.0
+        if (
+            is_in_row(row, BOOST)
+            and (
+                pk_version.parse(row[param_map[ALPAKA]][VERSION])
+                > pk_version.parse("0.8.0")
+                or row[param_map[ALPAKA]][VERSION] == "develop"
+            )
+            and pk_version.parse(row[param_map[BOOST]][VERSION])
+            < pk_version.parse("1.74.0")
+        ):
+            return False
+        if row_check_version(row, ALPAKA, "==", "develop") and row_check_version(
+            row, CMAKE, "<", "3.22"
+        ):
+            return False
 
     # CUDA 11.3+ is only supported by alpaka 0.7.0 an newer
     if (


### PR DESCRIPTION
- Fix alpine and typeguard version for the job generator
- set lowest supported version for alpaka develop branch to cmake 3.22
- use environment variable for AMD GPU architecture