### PR TITLE
Gitlab CI: update to container version 3.1

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,24 +1,10 @@
-################################################################################
-# VIKUNJA_CXX                             : {g++, clang++}
-#   [g++]                                 : {7, 8, 9, 10, 11} <list>
-#   [clang++]                             : {4.0, 5.0, 6.0, 7, 8, 9, 10} <list>
-# ALPAKA_CXX_STANDARD                     . {17, 20}, optional
-# VIKUNJA_BOOST_VERSIONS                  : {1.65.1, 1.66.0, 1.67.0, 1.68.0, 1.69.0, 1.70.0, 1.71.0, 1.72.0, 1.73.0} <list>
-# VIKUNJA_BUILD_TYPE                      : {Debug, Release}
-# VIKUNJA_CMAKE_ARGS                      : <string>
-# VIKUNJA_CXX_TEST                        : {ON}, optional
-
-#include:
-#  - local: '/ci/custom_jobs/integration_test.yml'
-
 variables:
-  CONTAINER_VERSION: "3.0"
+  CONTAINER_VERSION: "3.1"
 
 stages:
   - validate
   - generator
   - run-test-jobs
-  #- compile-and-run
 
 ################################################################################
 # Check code formation with clang-format

--- a/ci/custom_jobs/integration_test.yml
+++ b/ci/custom_jobs/integration_test.yml
@@ -2,6 +2,7 @@ integration_add_subdirectory:
   image: registry.hzdr.de/crp/alpaka-group-container/alpaka-ci-ubuntu20.04
   stage: compile-and-run
   variables:
+    VIKUNJA_CI_CMAKE_VERSION: "3.22"
     VIKUNJA_BOOST_VERSIONS: 1.74.0
     VIKUNJA_GCC_VERSION: 9
   script:
@@ -18,6 +19,7 @@ integration_find_package:
   image: registry.hzdr.de/crp/alpaka-group-container/alpaka-ci-ubuntu20.04
   stage: compile-and-run
   variables:
+    VIKUNJA_CI_CMAKE_VERSION: "3.22"
     VIKUNJA_BOOST_VERSIONS: 1.74.0
     VIKUNJA_GCC_VERSION: 9
   script:

--- a/ci/gitlab_scripts/integration_test/prepare_add_subdirectory.sh
+++ b/ci/gitlab_scripts/integration_test/prepare_add_subdirectory.sh
@@ -13,6 +13,17 @@ set -o pipefail
 
 echo "CUPLA_TRANSFORM_DIR -> ${CUPLA_TRANSFORM_DIR}"
 
+#####################################
+# find CMake
+#####################################
+
+if agc-manager -e cmake@${VIKUNJA_CI_CMAKE_VERSION} ; then
+    export VIKUNJA_CI_CMAKE_ROOT=$(agc-manager -b cmake@${VIKUNJA_CI_CMAKE_VERSION})
+else
+    echo "cmake ${VIKUNJA_CI_CMAKE_VERSION} is not available"
+    exit 1
+fi
+
 ###############################################
 # find boost
 ###############################################

--- a/ci/gitlab_scripts/integration_test/prepare_find_package.sh
+++ b/ci/gitlab_scripts/integration_test/prepare_find_package.sh
@@ -13,6 +13,17 @@ set -o pipefail
 
 echo "CUPLA_TRANSFORM_DIR -> ${CUPLA_TRANSFORM_DIR}"
 
+#####################################
+# find CMake
+#####################################
+
+if agc-manager -e cmake@${VIKUNJA_CI_CMAKE_VERSION} ; then
+    export VIKUNJA_CI_CMAKE_ROOT=$(agc-manager -b cmake@${VIKUNJA_CI_CMAKE_VERSION})
+else
+    echo "cmake ${VIKUNJA_CI_CMAKE_VERSION} is not available"
+    exit 1
+fi
+
 ###############################################
 # find boost
 ###############################################
@@ -36,9 +47,9 @@ cd alpaka
 # use this specific alpaka version because of bug fixes for alpaka_add_library
 git checkout 261bdf70f359b3d97dfdfb3cc2bd39ec0472c8d1
 mkdir build && cd build
-cmake .. -DBOOST_ROOT=${VIKUNJA_BOOST_ROOT}
-cmake --build .
-cmake --install .
+$VIKUNJA_CI_CMAKE_ROOT/bin/cmake .. -DBOOST_ROOT=${VIKUNJA_BOOST_ROOT}
+$VIKUNJA_CI_CMAKE_ROOT/bin/cmake --build .
+$VIKUNJA_CI_CMAKE_ROOT/bin/cmake --install .
 cd $CI_PROJECT_DIR
 rm -r alpaka
 
@@ -52,9 +63,9 @@ cd cupla
 # use this specific cupla version because of a bug fix in the CMakeLists.txt
 git checkout d83fe957009e7b3774f423b3f53887a7af50aabe
 mkdir build && cd build
-cmake .. -DBOOST_ROOT=${VIKUNJA_BOOST_ROOT}
-cmake --build .
-cmake --install .
+$VIKUNJA_CI_CMAKE_ROOT/bin/cmake .. -DBOOST_ROOT=${VIKUNJA_BOOST_ROOT}
+$VIKUNJA_CI_CMAKE_ROOT/bin/cmake --build .
+$VIKUNJA_CI_CMAKE_ROOT/bin/cmake --install .
 cd $CI_PROJECT_DIR
 rm -r cupla
 
@@ -64,9 +75,9 @@ rm -r cupla
 
 cd $CI_PROJECT_DIR
 mkdir build && cd build
-cmake .. -DBOOST_ROOT=${VIKUNJA_BOOST_ROOT}
-cmake --build .
-cmake --install .
+$VIKUNJA_CI_CMAKE_ROOT/bin/cmake .. -DBOOST_ROOT=${VIKUNJA_BOOST_ROOT}
+$VIKUNJA_CI_CMAKE_ROOT/bin/cmake --build .
+$VIKUNJA_CI_CMAKE_ROOT/bin/cmake --install .
 cd $CI_PROJECT_DIR
 
 ###############################################

--- a/ci/gitlab_scripts/integration_test/run.sh
+++ b/ci/gitlab_scripts/integration_test/run.sh
@@ -13,8 +13,8 @@ set -o pipefail
 
 cd $CUPLA_TRANSFORM_DIR
 mkdir build && cd build
-cmake .. -DBOOST_ROOT=${VIKUNJA_BOOST_ROOT} -DALPAKA_ACC_CPU_B_SEQ_T_SEQ_ENABLE=ON
-cmake --build .
+$VIKUNJA_CI_CMAKE_ROOT/bin/cmake .. -DBOOST_ROOT=${VIKUNJA_BOOST_ROOT} -DALPAKA_ACC_CPU_B_SEQ_T_SEQ_ENABLE=ON
+$VIKUNJA_CI_CMAKE_ROOT/bin/cmake --build .
 ./cuplaVikReduceSingleExe
 ./cuplaVikReduceStaticLinkedExe
 ./cuplaVikReduceDynamicLinkedExe

--- a/ci/job_generator/versions.py
+++ b/ci/job_generator/versions.py
@@ -8,17 +8,17 @@ from vikunja_globals import *  # pylint: disable=wildcard-import,unused-wildcard
 
 
 sw_versions: Dict[str, List[str]] = {
-    GCC: ["7", "8", "9", "10", "11"],
+    GCC: ["9", "10", "11"],
     CLANG: ["7", "8", "9", "10", "11", "12", "13", "14", "15"],
     NVCC: ["11.0", "11.1", "11.2", "11.3", "11.4", "11.5", "11.6"],
-    HIPCC: ["4.3", "4.5", "5.0", "5.1", "5.2"],
+    HIPCC: ["5.0", "5.1", "5.2"],
     BACKENDS: [
         ALPAKA_ACC_CPU_B_OMP2_T_SEQ_ENABLE,
         ALPAKA_ACC_GPU_CUDA_ENABLE,
         # ALPAKA_ACC_GPU_HIP_ENABLE,
     ],
     UBUNTU: ["20.04"],
-    CMAKE: ["3.18.6", "3.19.8", "3.20.6", "3.21.6", "3.22.3"],
+    CMAKE: ["3.22"],
     BOOST: [
         "1.74.0",
         "1.75.0",

--- a/ci/job_generator/vikunja_filter.py
+++ b/ci/job_generator/vikunja_filter.py
@@ -26,10 +26,26 @@ def vikunja_post_filter(row: List) -> bool:
             < pk_version.parse("1.74.0")
         ):
             return False
-        if row_check_version(row, ALPAKA, "==", "develop") and row_check_version(
-            row, CMAKE, "<", "3.22"
-        ):
-            return False
+
+        # develop branch with commit 88860c9 supports
+        # >= CMake 3.22
+        # >= Clang 9
+        # >= GCC 9
+        if row_check_version(row, ALPAKA, "==", "develop"):
+            if row_check_version(row, CMAKE, "<", "3.22"):
+                return False
+            if row_check_name(row, HOST_COMPILER, "==", GCC) and row_check_version(
+                row, HOST_COMPILER, "<", "9"
+            ):
+                return False
+            if row_check_name(row, HOST_COMPILER, "==", CLANG) and row_check_version(
+                row, HOST_COMPILER, "<", "9"
+            ):
+                return False
+            if row_check_name(
+                row, DEVICE_COMPILER, "==", CLANG_CUDA
+            ) and row_check_version(row, DEVICE_COMPILER, "<", "9"):
+                return False
 
     # CUDA 11.3+ is only supported by alpaka 0.7.0 an newer
     if (


### PR DESCRIPTION
- does not test GCC 8 and below
- does not test current alpaka develop branch with Clang 8 and below 